### PR TITLE
removed historical html element 1999 XHTML namespace

### DIFF
--- a/Allfiles/Mod06/Democode/positioning.html
+++ b/Allfiles/Mod06/Democode/positioning.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
 <head>
   <title>Positioning Demo</title>
   <style type="text/css">


### PR DESCRIPTION
Removed the XHTML namespace from the module 6 demo code - the only file where this namespace was left.