### PR TITLE
Updated Module 8 Lab's GPS Coordinates

### DIFF
--- a/Instructions/20480C_MOD08_LAB_MANUAL.md
+++ b/Instructions/20480C_MOD08_LAB_MANUAL.md
@@ -190,7 +190,7 @@ You will use the Geolocation API to get the visitor’s current location, and th
     ```javascript
         const conferenceLocation = {
             latitude: 47.6097,  // decimal degrees
-            longitude: 122.3331 // decimal degrees
+            longitude: -122.3331 // decimal degrees
         };
     ```
 

--- a/Instructions/20480C_MOD08_LAK.md
+++ b/Instructions/20480C_MOD08_LAK.md
@@ -275,7 +275,7 @@ Ensure that you have cloned the 20480C directory from GitHub (**https://github.c
     ```javascript
         const conferenceLocation = {
             latitude: 47.6097,  // decimal degrees
-            longitude: 122.3331 // decimal degrees
+            longitude: -122.3331 // decimal degrees
         };
     ```
 


### PR DESCRIPTION
The conference location GPS coordinates (47.6097, 122.3331) incorrectly point to a location in China. The correct coordinate (47.6097, -122.3331) points to a location in Seattle.

## Changes
- Updated Module 8 Lab Answer Key
- Updated Module 8 Lab Guide